### PR TITLE
Add MemoryCacheBroker for Transparent Caching Execution

### DIFF
--- a/memorycache_broker.go
+++ b/memorycache_broker.go
@@ -1,0 +1,55 @@
+package memorycache
+
+import (
+	"time"
+)
+
+// MemoryCacheBroker provides a transparent caching layer by leveraging the underlying cache provider.
+// It wraps a cache key and TTL configuration for caching operations.
+type MemoryCacheBroker[T any] struct {
+	key string
+	ttl time.Duration
+}
+
+// NewMemoryCacheBroker creates a new CacheBroker with the specified key and TTL.
+func NewMemoryCacheBroker[T any](key string, ttl time.Duration) *MemoryCacheBroker[T] {
+	return &MemoryCacheBroker[T]{
+		key: key,
+		ttl: ttl,
+	}
+}
+
+// Exec executes the provided data-fetching function through the cache.
+// It first attempts to retrieve the data from the cache using the broker's key.
+// If the data is not present, it calls getData to fetch the data from the source,
+// then stores the result in the cache with the broker's TTL.
+func (b *MemoryCacheBroker[T]) Exec(getData func() (T, error)) (T, error) {
+	// Create a cache provider for the given key.
+	cacheProvider := NewMemoryCacheProvider[T](b.key)
+
+	// Attempt to retrieve data from the cache.
+	if cachedData, err := cacheProvider.Get(); err == nil {
+		// Data found in cache; return it.
+		return cachedData, nil
+	}
+
+	// Data not found in cache; fetch it using the provided function.
+	fetchedData, err := getData()
+	if err != nil {
+		// Return a zero value along with the error if data fetching fails.
+		var zero T
+		return zero, err
+	}
+
+	// Store the newly fetched data in the cache with the configured TTL.
+	cacheProvider.Set(fetchedData, b.ttl)
+
+	return fetchedData, nil
+}
+
+// ClearCache removes the cached data associated with the broker's key.
+// This is mainly used for testing purposes.
+func (b *MemoryCacheBroker[T]) ClearCache() {
+	cacheProvider := NewMemoryCacheProvider[T](b.key)
+	cacheProvider.Clear()
+}

--- a/memorycache_broker_test.go
+++ b/memorycache_broker_test.go
@@ -1,0 +1,58 @@
+package memorycache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemoryCacheBroker_Exec(t *testing.T) {
+	// Test that when the cache is empty, data is fetched from the origin.
+	t.Run("fetches data from origin when cache is empty", func(t *testing.T) {
+		cacheKey := "unique-key-for-cache-miss"
+		expiration := 1 * time.Second
+		broker := NewMemoryCacheBroker[any](cacheKey, expiration)
+
+		// Flag to verify if the getData function is executed.
+		called := false
+
+		// Execute the broker; since the cache is empty, the getData function should be called.
+		_, err := broker.Exec(func() (any, error) {
+			called = true
+			return struct{}{}, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error during Exec: %v", err)
+		}
+		if !called {
+			t.Errorf("expected getData to be called when cache is empty, but it was not")
+		}
+	})
+
+	// Test that when the cache has data, the cached value is returned and the getData function is not executed.
+	t.Run("returns cached data when present", func(t *testing.T) {
+		cacheKey := "key-for-cached-data"
+		expiration := 1000 * time.Second // Use a long TTL to keep data in cache
+		broker := NewMemoryCacheBroker[any](cacheKey, expiration)
+
+		// First call: populate the cache.
+		_, err := broker.Exec(func() (any, error) {
+			return struct{}{}, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error during first Exec call: %v", err)
+		}
+
+		// Second call: verify that the getData function is not executed.
+		called := false
+		_, err = broker.Exec(func() (any, error) {
+			called = true
+			return struct{}{}, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error during second Exec call: %v", err)
+		}
+		if called {
+			t.Errorf("expected cached data to be returned, but getData was called")
+		}
+	})
+}


### PR DESCRIPTION
This PR introduces a new component, MemoryCacheBroker, into the memorycache package. The MemoryCacheBroker provides a transparent caching layer by leveraging the underlying MemoryCacheProvider. It simplifies caching logic by executing a data-fetching function through the cache, ensuring that:

- If the data exists in the cache, it is returned immediately.
- If the data is not present, the data-fetching function is executed, its result is cached with a specified TTL, and then returned.

### Key Changes
- **MemoryCacheBroker Implementation**
  - Added a new `MemoryCacheBroker` generic type that wraps a cache key and a TTL (time-to-live) configuration.
  - Introduced the `Exec` method:
    - Attempts to retrieve data from the cache.
    - If the cache is empty, calls the provided `getData` function to fetch data, stores the result in the cache using the specified TTL, and returns it.
  - Added a `ClearCache` method for clearing the cached data, primarily used for testing purposes.

- **Test Enhancements**
  - Updated tests to verify the correct behavior of the broker.
  - Utilized subtests (via `t.Run`) to clearly separate scenarios:
    - **Cache Miss**: Ensuring that when the cache is empty, the data-fetching function is executed.
    - **Cache Hit**: Ensuring that when the cache contains data, the data-fetching function is not called again.
  - Improved test naming and error messages for better clarity.

- **Code Refactoring**
  - Updated variable and method names to natural English expressions.
  - Added comprehensive English comments throughout the code.
  - Ensured consistency by using pointer receivers and enhancing error handling.
