### PR TITLE
feat: deduplicate concurrent cache misses in MemoryCacheBroker and guard nil fetcher

### DIFF
--- a/memorycache_broker_test.go
+++ b/memorycache_broker_test.go
@@ -1,6 +1,9 @@
 package memorycache
 
 import (
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -53,6 +56,93 @@ func TestMemoryCacheBroker_Exec(t *testing.T) {
 		}
 		if called {
 			t.Errorf("expected cached data to be returned, but getData was called")
+		}
+	})
+
+	t.Run("returns error when data fetcher is nil", func(t *testing.T) {
+		cacheKey := "key-for-nil-fetcher"
+		sharedCache := cache.New(DefaultExpiration, DefaultCleanupInterval)
+		broker := NewMemoryCacheBroker[any](cacheKey, 1*time.Second, WithCacheClient(sharedCache))
+		broker.Clear()
+
+		if _, err := broker.Exec(nil); !errors.Is(err, ErrNilDataFetcher) {
+			t.Fatalf("expected ErrNilDataFetcher, got %v", err)
+		}
+	})
+
+	t.Run("does not cache failed origin result", func(t *testing.T) {
+		cacheKey := "key-for-origin-error"
+		sharedCache := cache.New(DefaultExpiration, DefaultCleanupInterval)
+		broker := NewMemoryCacheBroker[any](cacheKey, 1*time.Second, WithCacheClient(sharedCache))
+		broker.Clear()
+
+		originErr := errors.New("origin failure")
+		calls := 0
+
+		if _, err := broker.Exec(func() (any, error) {
+			calls++
+			return nil, originErr
+		}); !errors.Is(err, originErr) {
+			t.Fatalf("expected origin error, got %v", err)
+		}
+
+		value, err := broker.Exec(func() (any, error) {
+			calls++
+			return "fresh", nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error on second Exec: %v", err)
+		}
+		if value != "fresh" {
+			t.Fatalf("expected fresh value, got %v", value)
+		}
+		if calls != 2 {
+			t.Fatalf("expected origin function to be called twice, got %d", calls)
+		}
+	})
+
+	t.Run("deduplicates concurrent cache misses", func(t *testing.T) {
+		cacheKey := "key-for-concurrent-miss-dedup"
+		sharedCache := cache.New(DefaultExpiration, DefaultCleanupInterval)
+		broker := NewMemoryCacheBroker[string](cacheKey, 1*time.Second, WithCacheClient(sharedCache))
+		broker.Clear()
+
+		const workers = 16
+		start := make(chan struct{})
+		errCh := make(chan error, workers)
+		var calls int32
+		var wg sync.WaitGroup
+
+		for range workers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				value, err := broker.Exec(func() (string, error) {
+					atomic.AddInt32(&calls, 1)
+					time.Sleep(30 * time.Millisecond)
+					return "deduped", nil
+				})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if value != "deduped" {
+					errCh <- errors.New("unexpected value returned from cache broker")
+				}
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+		close(errCh)
+
+		for err := range errCh {
+			t.Fatalf("unexpected concurrent Exec error: %v", err)
+		}
+
+		if got := atomic.LoadInt32(&calls); got != 1 {
+			t.Fatalf("expected origin function to be called once, got %d", got)
 		}
 	})
 }


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the in-memory cache provider and broker, focusing on error handling, concurrent cache miss deduplication, and configuration flexibility. Notably, it adds protection against concurrent cache misses, improves error reporting, and enhances test coverage for both typical and edge-case behaviors.

**Concurrency and Deduplication:**
- Added a mutex (`mu`) to `MemoryCacheBroker` and updated the `Exec` method to ensure that only one concurrent cache miss triggers a fetch from the origin, deduplicating concurrent cache misses for the same key. This prevents redundant work and potential race conditions. [[1]](diffhunk://#diff-fb7a72ddc043f95bec81724a6a010ac13fb05a454c9c8b103da3dad124e68627R5) [[2]](diffhunk://#diff-fb7a72ddc043f95bec81724a6a010ac13fb05a454c9c8b103da3dad124e68627R14) [[3]](diffhunk://#diff-fb7a72ddc043f95bec81724a6a010ac13fb05a454c9c8b103da3dad124e68627R31-R46) [[4]](diffhunk://#diff-d85faf177c2ab535ce722b65874cbe1829d208d12c05e9d13296af97622e2de4R61-R147)

**Error Handling Improvements:**
- Introduced `ErrNilDataFetcher` to handle cases where a nil data-fetching function is passed to the broker, and updated the `Exec` method to return this error when appropriate. [[1]](diffhunk://#diff-a3f1a24f961277a681883997ac2f8e018b2a2e1cd970c0c95586f647adb10c3eL18-R22) [[2]](diffhunk://#diff-fb7a72ddc043f95bec81724a6a010ac13fb05a454c9c8b103da3dad124e68627R31-R46) [[3]](diffhunk://#diff-d85faf177c2ab535ce722b65874cbe1829d208d12c05e9d13296af97622e2de4R61-R147)
- Updated error creation to use the `errors.New` function instead of `fmt.Errorf` for consistency and clarity. [[1]](diffhunk://#diff-a3f1a24f961277a681883997ac2f8e018b2a2e1cd970c0c95586f647adb10c3eL4-R4) [[2]](diffhunk://#diff-a3f1a24f961277a681883997ac2f8e018b2a2e1cd970c0c95586f647adb10c3eL18-R22)

**Configuration and API Enhancements:**
- Enhanced provider configuration by allowing `WithCacheConfig` to override `WithCacheClient` and added a new `WithIsolatedCache` option for creating dedicated cache clients with default settings. [[1]](diffhunk://#diff-a3f1a24f961277a681883997ac2f8e018b2a2e1cd970c0c95586f647adb10c3eR33-R35) [[2]](diffhunk://#diff-a3f1a24f961277a681883997ac2f8e018b2a2e1cd970c0c95586f647adb10c3eL44-R59) [[3]](diffhunk://#diff-a3f1a24f961277a681883997ac2f8e018b2a2e1cd970c0c95586f647adb10c3eR72-R75) [[4]](diffhunk://#diff-37ebd789476353a03d69799c5394a9c0540fbc7c2be50649ff9cc32474be66a0R86-R122)
- Ensured that `WithCacheConfig` takes precedence over `WithCacheClient` when both are provided, and added tests to verify the correct behavior. [[1]](diffhunk://#diff-a3f1a24f961277a681883997ac2f8e018b2a2e1cd970c0c95586f647adb10c3eR72-R75) [[2]](diffhunk://#diff-37ebd789476353a03d69799c5394a9c0540fbc7c2be50649ff9cc32474be66a0R86-R122)

**Testing and Coverage:**
- Added comprehensive tests for new behaviors, including: error on nil data fetcher, ensuring failed origin fetches are not cached, deduplication of concurrent cache misses, type assertion failures, and configuration precedence. [[1]](diffhunk://#diff-d85faf177c2ab535ce722b65874cbe1829d208d12c05e9d13296af97622e2de4R4-R6) [[2]](diffhunk://#diff-d85faf177c2ab535ce722b65874cbe1829d208d12c05e9d13296af97622e2de4R61-R147) [[3]](diffhunk://#diff-37ebd789476353a03d69799c5394a9c0540fbc7c2be50649ff9cc32474be66a0R4) [[4]](diffhunk://#diff-37ebd789476353a03d69799c5394a9c0540fbc7c2be50649ff9cc32474be66a0R86-R122)