### PR TITLE
feat: change module/import path to github.com/usuginus/go-cache-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# go-cache-helper
+# go-cache-kit
 
-go-cache-helper is a lightweight, generic caching helper for Go that simplifies the use of in-memory caching. It provides a type-safe cache provider and a broker that transparently executes functions through the cache, reducing repetitive cache management code in your applications.
+go-cache-kit is a lightweight, generic caching helper for Go that simplifies the use of in-memory caching. It provides a type-safe cache provider and a broker that transparently executes functions through the cache, reducing repetitive cache management code in your applications.
 
 ## Overview
 
@@ -19,20 +19,21 @@ These components can help you implement transparent caching logic in your Go pro
 - Type-safe caching: Use Go generics to store and retrieve any data type.
 - Configurable expiration: Set custom expiration times for cache entries.
 - Transparent execution: The broker automatically handles cache misses by invoking a data-fetching function.
+- Concurrent miss de-duplication: The broker serializes cache misses per key to avoid duplicate origin fetches.
 - Injectable cache client: Provide your own `go-cache` instance or custom configuration when needed.
 
 ## Installation
 
-To install go-cache-helper, use go get:
+To install go-cache-kit, use go get:
 
 ```
-go get github.com/usuginus/go-cache-helper
+go get github.com/usuginus/go-cache-kit
 ```
 
 Then import the package in your code:
 
 ```
-import memorycache "github.com/usuginus/go-cache-helper"
+import memorycache "github.com/usuginus/go-cache-kit"
 ```
 
 ## Usage
@@ -46,7 +47,7 @@ import (
 	"fmt"
 	"time"
 
-	memorycache "github.com/usuginus/go-cache-helper"
+	memorycache "github.com/usuginus/go-cache-kit"
 )
 
 func main() {
@@ -75,7 +76,7 @@ import (
 	"fmt"
 	"time"
 
-	memorycache "github.com/usuginus/go-cache-helper"
+	memorycache "github.com/usuginus/go-cache-kit"
 )
 
 func main() {
@@ -110,7 +111,7 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
-	memorycache "github.com/usuginus/go-cache-helper"
+	memorycache "github.com/usuginus/go-cache-kit"
 )
 
 func main() {
@@ -124,3 +125,6 @@ func main() {
 	// ...
 }
 ```
+
+By default, providers use a shared in-memory cache client. Use unique keys across your application.
+If you want a dedicated cache client per provider, use `memorycache.WithIsolatedCache()` or `memorycache.WithCacheConfig(...)`.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/KoichiGinu/go-cache-helper
+module github.com/usuginus/go-cache-kit
 
 go 1.22.2
 


### PR DESCRIPTION
This pull request updates the package and module name from `go-cache-helper` to `go-cache-kit` throughout the documentation and code, and improves the README with additional usage notes and a new feature description. The most important changes are:

**Project renaming and import path updates:**
* Changed all references in the `README.md` and `go.mod` from `go-cache-helper` to `go-cache-kit`, including installation instructions and import statements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R36) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R50) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R79) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R114) [[6]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1)

**Documentation improvements:**
* Added a note about using unique keys and how to configure isolated cache clients in the `README.md` usage section.
* Documented a new feature: "Concurrent miss de-duplication", explaining that the broker serializes cache misses per key to avoid duplicate origin fetches.