### PR TITLE
docs: clarify broker miss deduplication scope and add license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These components can help you implement transparent caching logic in your Go pro
 - Type-safe caching: Use Go generics to store and retrieve any data type.
 - Configurable expiration: Set custom expiration times for cache entries.
 - Transparent execution: The broker automatically handles cache misses by invoking a data-fetching function.
-- Concurrent miss de-duplication: The broker serializes cache misses per key to avoid duplicate origin fetches.
+- Concurrent miss de-duplication: Each broker instance serializes cache misses to avoid duplicate origin fetches.
 - Injectable cache client: Provide your own `go-cache` instance or custom configuration when needed.
 
 ## Installation
@@ -128,3 +128,7 @@ func main() {
 
 By default, providers use a shared in-memory cache client. Use unique keys across your application.
 If you want a dedicated cache client per provider, use `memorycache.WithIsolatedCache()` or `memorycache.WithCacheConfig(...)`.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE).


### PR DESCRIPTION
This pull request introduces a clarification to the caching logic description and adds license information to the `README.md` file. These updates improve documentation clarity and provide important legal context for users.

Documentation improvements:

* Clarified the description of concurrent miss de-duplication to specify that each broker instance serializes cache misses, preventing duplicate origin fetches per instance.

Legal and licensing:

* Added a section specifying that the project is licensed under the MIT License, with a link to the `LICENSE` file.