### PR TITLE
chore: add CI workflow and golangci-lint configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: go vet ./...
 
   lint:
-    name: Lint (golangci-lint + staticcheck)
+    name: Lint (golangci-lint)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Go ${{ matrix.go-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.22.x"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Run unit tests
+        run: go test ./...
+
+      - name: Run race tests
+        run: go test -race ./...
+
+      - name: Run vet
+        run: go vet ./...
+
+  lint:
+    name: Lint (golangci-lint + staticcheck)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.61.0
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - govet
+    - staticcheck
+    - unused


### PR DESCRIPTION
This pull request introduces a continuous integration (CI) workflow for the project and configures linting standards for Go code. The main changes set up automated testing and code quality checks using GitHub Actions and `golangci-lint`.

**CI/CD Workflow Setup:**

* Added a `.github/workflows/ci.yml` file to define a GitHub Actions workflow that runs on pushes and pull requests, including:
  - Automated unit tests, race condition tests, and `go vet` checks for Go 1.22.x.
  - A linting job that runs `golangci-lint` and `staticcheck` to enforce code quality.

**Linting Configuration:**

* Added a `.golangci.yml` configuration file to specify enabled linters (`errcheck`, `gofmt`, `govet`, `staticcheck`, `unused`) and set a timeout for linting runs.