### PR TITLE
feat: add benchmarks for provider and broker

### DIFF
--- a/memorycache_benchmark_test.go
+++ b/memorycache_benchmark_test.go
@@ -1,0 +1,130 @@
+package memorycache
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+func newBenchmarkProvider(b *testing.B, key string) *MemoryCacheProvider[int] {
+	b.Helper()
+	client := cache.New(10*time.Minute, 10*time.Minute)
+	provider, err := NewMemoryCacheProvider[int](key, WithCacheClient(client))
+	if err != nil {
+		b.Fatalf("failed to create benchmark provider: %v", err)
+	}
+	return provider
+}
+
+func newBenchmarkBroker(b *testing.B, key string, ttl time.Duration) *MemoryCacheBroker[int] {
+	b.Helper()
+	client := cache.New(10*time.Minute, 10*time.Minute)
+	broker, err := NewMemoryCacheBroker[int](key, ttl, WithCacheClient(client))
+	if err != nil {
+		b.Fatalf("failed to create benchmark broker: %v", err)
+	}
+	return broker
+}
+
+func BenchmarkMemoryCacheProviderSet(b *testing.B) {
+	provider := newBenchmarkProvider(b, "bench:provider:set")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		provider.Set(i, time.Minute)
+	}
+}
+
+func BenchmarkMemoryCacheProviderGetHit(b *testing.B) {
+	provider := newBenchmarkProvider(b, "bench:provider:get-hit")
+	provider.Set(42, time.Minute)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := provider.Get(); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkMemoryCacheProviderGetMiss(b *testing.B) {
+	provider := newBenchmarkProvider(b, "bench:provider:get-miss")
+	provider.Clear()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := provider.Get(); err != ErrDataNotFound {
+			b.Fatalf("expected ErrDataNotFound, got: %v", err)
+		}
+	}
+}
+
+func BenchmarkMemoryCacheBrokerExecHit(b *testing.B) {
+	broker := newBenchmarkBroker(b, "bench:broker:hit", time.Minute)
+	if _, err := broker.Exec(func() (int, error) { return 42, nil }); err != nil {
+		b.Fatalf("failed to warm cache: %v", err)
+	}
+
+	fetcher := func() (int, error) {
+		b.Fatalf("fetcher should not be called on cache hit")
+		return 0, nil
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := broker.Exec(fetcher); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkMemoryCacheBrokerExecMiss(b *testing.B) {
+	broker := newBenchmarkBroker(b, "bench:broker:miss", time.Minute)
+	var calls int64
+	fetcher := func() (int, error) {
+		atomic.AddInt64(&calls, 1)
+		return 42, nil
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		broker.Clear()
+		if _, err := broker.Exec(fetcher); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	b.StopTimer()
+	if calls != int64(b.N) {
+		b.Fatalf("expected fetcher calls %d, got %d", b.N, calls)
+	}
+}
+
+func BenchmarkMemoryCacheBrokerExecHitParallel(b *testing.B) {
+	broker := newBenchmarkBroker(b, "bench:broker:hit-parallel", time.Minute)
+	if _, err := broker.Exec(func() (int, error) { return 42, nil }); err != nil {
+		b.Fatalf("failed to warm cache: %v", err)
+	}
+
+	fetcher := func() (int, error) {
+		b.Fatalf("fetcher should not be called on cache hit")
+		return 0, nil
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := broker.Exec(fetcher); err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This pull request adds comprehensive benchmarking for the `go-cache-kit` package and significantly improves the documentation in `README.md` to clarify configuration options, validation rules, and now includes benchmark results. The most important changes are grouped below:

### Benchmarking

* Added a new file `memorycache_benchmark_test.go` containing a full suite of microbenchmarks for `MemoryCacheProvider` and `MemoryCacheBroker`, covering set, get (hit/miss), broker execution (hit/miss), and parallel execution scenarios. This provides detailed performance and allocation metrics for the core cache operations.

### Documentation improvements

* Expanded the `README.md` to include a new "Benchmark" section, sample benchmark results, and instructions for running benchmarks, giving users visibility into package performance.
* Clarified and reorganized the "Options" section in `README.md`, making configuration options and their precedence more explicit and easier to understand.
* Improved the "Validation Rules" section for clearer error handling documentation, including which errors are returned for invalid input.
* Made minor language and formatting improvements throughout the `README.md` for consistency and clarity, such as updating feature descriptions and minor code formatting. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52)