### PR TITLE
feat: add context-aware broker execution with ExecContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ func main() {
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -75,11 +74,11 @@ func main() {
 		return
 	}
 
-	value, err := broker.ExecContext(context.Background(), func(context.Context) (string, error) {
+	value, err := broker.Exec(func() (string, error) {
 		return "Hello, Cached World!", nil
 	})
 	if err != nil {
-		fmt.Println("broker exec context error:", err)
+		fmt.Println("broker exec error:", err)
 		return
 	}
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It wraps [go-cache](https://github.com/patrickmn/go-cache) with type-safe APIs a
 
 - Type-safe cache operations with Go generics
 - Cache-aside execution via `MemoryCacheBroker.Exec`
+- Context-aware cache-aside execution via `MemoryCacheBroker.ExecContext`
 - Concurrent miss de-duplication per broker instance
 - Flexible cache configuration via options
 - Constructor input validation (`key`, `ttl`, and nil custom client checks)
@@ -60,6 +61,7 @@ func main() {
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -73,11 +75,11 @@ func main() {
 		return
 	}
 
-	value, err := broker.Exec(func() (string, error) {
+	value, err := broker.ExecContext(context.Background(), func(context.Context) (string, error) {
 		return "Hello, Cached World!", nil
 	})
 	if err != nil {
-		fmt.Println("broker exec error:", err)
+		fmt.Println("broker exec context error:", err)
 		return
 	}
 
@@ -102,6 +104,7 @@ Use unique keys across your application when relying on this shared default.
 - `WithCacheClient(nil)` is rejected (`ErrNilCacheClient`)
 - `NewMemoryCacheBroker(...)` rejects invalid TTL (`ErrInvalidCacheTTL`)
 - `MemoryCacheBroker.Exec(nil)` is rejected (`ErrNilDataFetcher`)
+- `MemoryCacheBroker.ExecContext(..., nil)` is rejected (`ErrNilDataFetcher`)
 
 TTL is valid when it is positive, `cache.DefaultExpiration`, or `cache.NoExpiration`.
 


### PR DESCRIPTION
This pull request adds context-aware cache-aside execution to the `MemoryCacheBroker` by introducing the new `ExecContext` method. This enhancement allows cache operations to be context-aware, enabling features like context cancellation and value propagation. The documentation and tests have been updated to reflect and verify this new functionality.

**Context-aware cache-aside execution:**

* Added the `ExecContext` method to `MemoryCacheBroker`, allowing cache-aside execution that accepts a `context.Context` and passes it to the data fetcher. This enables context cancellation and value propagation during cache misses. (`memorycache_broker.go`, [[1]](diffhunk://#diff-fb7a72ddc043f95bec81724a6a010ac13fb05a454c9c8b103da3dad124e68627R47-R63) [[2]](diffhunk://#diff-fb7a72ddc043f95bec81724a6a010ac13fb05a454c9c8b103da3dad124e68627L64-R82)
* Updated the documentation in `README.md` to describe the new `ExecContext` method and its usage, including code examples and error handling details. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R82) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107)

**Testing improvements:**

* Added comprehensive tests for `ExecContext` to verify context propagation, cache hit/miss behavior, nil data fetcher handling, and correct handling of context cancellation. (`memorycache_broker_test.go`, [memorycache_broker_test.goR177-R274](diffhunk://#diff-d85faf177c2ab535ce722b65874cbe1829d208d12c05e9d13296af97622e2de4R177-R274))

**General updates:**

* Added necessary imports of the `context` package to relevant files. (`memorycache_broker.go`, [[1]](diffhunk://#diff-fb7a72ddc043f95bec81724a6a010ac13fb05a454c9c8b103da3dad124e68627R4); `memorycache_broker_test.go`, [[2]](diffhunk://#diff-d85faf177c2ab535ce722b65874cbe1829d208d12c05e9d13296af97622e2de4R4)